### PR TITLE
Allow setting URL in config file

### DIFF
--- a/cmd/deviceplane/configure/configure.go
+++ b/cmd/deviceplane/configure/configure.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 type ConfigValues struct {
 	AccessKey *string `yaml:"access-key,omitempty"`
 	Project   *string `yaml:"project,omitempty"`
+	Url       *string `yaml:"url,omitempty"`
 }
 
 func populateEmptyValuesFromConfig(c *kingpin.ParseContext) (err error) {
@@ -95,6 +97,13 @@ func populateEmptyValuesFromConfig(c *kingpin.ParseContext) (err error) {
 		if gConfig.Flags.Project == nil || *gConfig.Flags.Project == "" {
 			*gConfig.Flags.Project = *configValues.Project
 		}
+	}
+	if gConfig.Flags.APIEndpoint != nil {
+		u, err := url.Parse(*configValues.Url)
+		if err != nil {
+			return errors.Wrap(err, "invalid url")
+		}
+		*gConfig.Flags.APIEndpoint = u
 	}
 
 	return nil

--- a/cmd/deviceplane/main.go
+++ b/cmd/deviceplane/main.go
@@ -23,7 +23,7 @@ var (
 		ParsedCorrectly: app.Flag("internal-parsing-validator", "").Hidden().Default("true").Bool(),
 
 		Flags: global.ConfigFlags{
-			APIEndpoint: app.Flag("url", "API Endpoint.").Hidden().Default("https://cloud.deviceplane.com:443/api").URL(),
+			APIEndpoint: app.Flag("url", "API Endpoint.").Default("https://cloud.deviceplane.com:443/api").URL(),
 			AccessKey:   app.Flag("access-key", "Access key used for authentication. (env: DEVICEPLANE_ACCESS_KEY)").Envar("DEVICEPLANE_ACCESS_KEY").String(),
 			Project:     app.Flag("project", "Project name. (env: DEVICEPLANE_PROJECT)").Envar("DEVICEPLANE_PROJECT").String(),
 			ConfigFile:  app.Flag("config", "Config file to use.").Default("~/.deviceplane/config").String(),


### PR DESCRIPTION
* Update config YAML parser to read a key called `url`, which
  points to the APIEndpoint we'd like to use
* Unhide the `--url` CLI parameter
* These changes benefit users running self-hosted versions
  of the software

closes #1 